### PR TITLE
Added steps to monitor API endpoints using Apitally

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -6,6 +6,7 @@ import sys
 import logging
 
 import uvicorn
+from apitally.fastapi import ApitallyMiddleware
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from fastapi import (
     FastAPI,
@@ -47,6 +48,13 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# Add Apitally middleware
+apitally_client_id = os.environ.get('APITALLY_CLIENT_ID')
+if apitally_client_id:
+    app.add_middleware(ApitallyMiddleware,
+                       client_id=apitally_client_id,
+                       env="prod")
 
 logger = logging.getLogger(__name__)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ sqlalchemy
 httpx
 pytest
 bcrypt
+apitally[fastapi]


### PR DESCRIPTION
Added steps to add a `middleware` using `Apitally` to monitor endpoints.

## How to Run? ##
1. Install requirements - `pip install -r requirements.txt`
2. Generate `client_id` from Apitally
3. Set `APITALLY_CLIENT_ID` env variable
4. Start the `FastAPI` app
5. Start monitoring the requests on the dashboard